### PR TITLE
Add ability to set custom font

### DIFF
--- a/BNRDynamicTypeManager/Core/BNRDynamicTypeManager.h
+++ b/BNRDynamicTypeManager/Core/BNRDynamicTypeManager.h
@@ -34,12 +34,26 @@
    case where this can fail is if you save off a `UIFont`, then
    adjust the system-wide dynamic type size, then pass the saved
    (but now "stale") font to this method.
+ @warning This will not work if you set a custom font action. see 
+   -setFontAction:
 
  @param font The font to check against built-in text styles
 
  @return The matched text style, or `nil` if none was found.
  */
 + (NSString *)textStyleMatchingFont:(UIFont *)font;
+
+///---------------------------
+/// @name Customize font style
+///---------------------------
+
+/**
+ Added to support custom styles outside of the apple-provided ones.
+ By default there is a font action which calls through to UIFont preferredFontForTextStyle:
+
+ @param action The block to call, takes a string which represents the font style (E.G. UIFontTextStyleBody)
+ */
+- (void)setFontAction:(UIFont * (^)(NSString *))action;
 
 ///------------------------
 /// @name Watching Elements

--- a/Tests/BNRDynamicTypeManager Tests/BNRDynamicTypeManagerTests.m
+++ b/Tests/BNRDynamicTypeManager Tests/BNRDynamicTypeManagerTests.m
@@ -98,4 +98,26 @@
     expect(element.font).to.equal(headlineFont);
 }
 
+- (void)testSetCustomFontStyle {
+    UIFont *font = [UIFont fontWithName:@"Helvetica" size:13.0];
+    UILabel *label = [[UILabel alloc] init];
+    label.font = font;
+
+    UIFont *fancyFont = [UIFont fontWithName:@"MarkerFelt-Thin" size:20];
+
+    BNRDynamicTypeManager *manager = [[BNRDynamicTypeManager alloc] init];
+    [manager setFontAction:^UIFont *(NSString *style) {
+        if ([style isEqualToString:@"fancyStyle"]) {
+            return fancyFont;
+        }
+        return font;
+    }];
+
+    [manager watchLabel:label textStyle:@"fancyStyle"];
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:UIContentSizeCategoryDidChangeNotification object:nil];
+    expect(label.font).to.equal(fancyFont);
+
+}
+
 @end


### PR DESCRIPTION
Adds a block that can be set on any instance of BNRDynamicTypeManager which will allow the user to set a custom font (in the event that they have their own custom accessibility fonts, as described in http://stackoverflow.com/questions/20510094/how-to-use-a-custom-font-with-dynamic-text-sizes-in-ios7)