### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ UIButton *button = /* create a button */;
 
 iOS 7 and ARC.
 
-## Installation with Cocoapods
+## Installation with CocoaPods
 
 BNRDynamicTypeManager is available through [CocoaPods](http://cocoapods.org), to install
 it simply add the following line to your Podfile:
 
     pod "BNRDynamicTypeManager", "~> 0.1.0"
 
-## Installation without Cocoapods
+## Installation without CocoaPods
 
 Grab the class files (header and implementation) from the `BNRDynamicTypeManager/Core` and `BNRDynamicTypeManager/Controls` directory and copy them into your project.
 ## Author


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
